### PR TITLE
Add another area dropdown and extend note about the PCBs in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/heichips_project_submission.yml
+++ b/.github/ISSUE_TEMPLATE/heichips_project_submission.yml
@@ -65,7 +65,7 @@ body:
     id: pcb-requirements
     attributes:
       label: PCB Requirements
-      description: If we create a default PCB for all designs, do you have any special requirements? For example, a USB connector on specific pins, or a QSPI flash, etc. If not, leave empty.
+      description: If we create a default PCB for all designs, do you have any special requirements? For example, a USB connector on specific pins, or a QSPI flash, etc. If not, leave empty. We will definitely  add some LEDs and Pmod connectors to the board, so these do not have to be listed here.
 
   - type: textarea
     id: additional

--- a/.github/ISSUE_TEMPLATE/heichips_project_submission.yml
+++ b/.github/ISSUE_TEMPLATE/heichips_project_submission.yml
@@ -55,6 +55,18 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: small-template-merge
+    attributes:
+      label: Area usage less than half of the small template?
+      description: Do you need less than half of the small template's available area (<50000 µm²)? If yes, this would allow us to merge your design with another group's design and save some valuable area.
+      options:
+        - "No"
+        - "Yes"
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: location
     attributes:


### PR DESCRIPTION
This adds another dropdown menu for answering the question whether the design requires less than half the area of the small DEF template. Also extends the note about the PCB, stating that we will put some LEDs and Pmod headers on the board.